### PR TITLE
Custom projection handling

### DIFF
--- a/src/eodash_catalog/generate_indicators.py
+++ b/src/eodash_catalog/generate_indicators.py
@@ -31,6 +31,7 @@ from eodash_catalog.stac_handling import (
     add_base_overlay_info,
     add_collection_information,
     add_extra_fields,
+    add_projection_info,
     get_or_create_collection,
 )
 from eodash_catalog.utils import (
@@ -249,6 +250,7 @@ def process_collection_file(
                     raise ValueError("Type of Resource is not supported")
                 if collection:
                     add_single_item_if_collection_empty(collection)
+                    add_projection_info(resource, collection)
                     add_to_catalog(collection, catalog, resource, collection_config)
                 else:
                     raise Exception(f"No collection was generated for resource {resource}")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -145,7 +145,7 @@ def test_geojson_dataset_handled(catalog_output_folder):
             == "https://raw.githubusercontent.com/eodash/eodash_catalog/main/tests/test-data/regional_forecast.json"
         )
         # epsg code saved on collection
-        assert collection_json.get("proj:epsg", "") == 3035
+        assert collection_json["proj:epsg"] == 3035
     with open(os.path.join(item_dir, item_paths[0])) as fp:
         item_json = json.load(fp)
         # mimetype saved correctly
@@ -168,3 +168,19 @@ def test_cog_dataset_handled(catalog_output_folder):
         item_json = json.load(fp)
         assert item_json["assets"]["solar_power"]["type"] == "image/tiff"
         assert item_json["collection"] == collection_name
+
+
+def test_baselayer_with_custom_projection_added(catalog_output_folder):
+    collection_name = "test_indicator_grouping_collections"
+    root_collection_path = os.path.join(catalog_output_folder, collection_name)
+    with open(os.path.join(root_collection_path, "collection.json")) as fp:
+        indicator_json = json.load(fp)
+        baselayer_links = [
+            link
+            for link in indicator_json["links"]
+            if link.get("roles") and "baselayer" in link["roles"]
+        ]
+        # test that manual BaseLayers definition it did overwrite default_baselayers, so there is just 1
+        assert len(baselayer_links) == 1
+        # test that custom proj4 definition is added to link
+        assert baselayer_links[0]["proj4_def"]["name"] == "ORTHO:680500"

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -180,7 +180,8 @@ def test_baselayer_with_custom_projection_added(catalog_output_folder):
             for link in indicator_json["links"]
             if link.get("roles") and "baselayer" in link["roles"]
         ]
-        # test that manual BaseLayers definition it did overwrite default_baselayers, so there is just 1
+        # test that manual BaseLayers definition
+        # overwrites default_baselayers, so there is just 1
         assert len(baselayer_links) == 1
         # test that custom proj4 definition is added to link
         assert baselayer_links[0]["proj4_def"]["name"] == "ORTHO:680500"

--- a/tests/testing-indicators/test_indicator.yaml
+++ b/tests/testing-indicators/test_indicator.yaml
@@ -6,3 +6,15 @@ MapProjection: 3035
 Collections:
   - test_tif_demo_1
   - test_tif_demo_2
+BaseLayers:
+  - id: sx-cat_ortho680500
+    name: Terrain Light Stereographic North
+    url: '//sxcat-demo.eox.at/sxcat_maps/wms'
+    layers: sx-cat_ortho680500
+    attribution: '{ Terrain light: Data &copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors and <a href="//maps.eox.at/#data" target="_blank">others</a>, Rendering &copy; <a href="http://eox.at" target="_blank">EOX</a> }'
+    visible: false
+    protocol: wms
+    DataProjection: 
+      name: 'ORTHO:680500'
+      def: '+proj=ortho +lat_0=90 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs'
+


### PR DESCRIPTION
closes https://github.com/eodash/eodash_catalog/issues/9

adds projection information to all Items, Assets and Collections:
1. in a form of `proj:epsg:<number>` in case endpoint["DataProjection"] is set as integer (`3035`) or string (`EPSG:3035`) - This way the `registerProjectionFromCode` of EOxMap should be used
2. in a form of `proj4_def:<object>` in case endpoint["DataProjection"] is set as mapping in YAML - This way the `registerProjection` of EOxMap should be used