### PR TITLE
feat: bubble up thumbnail to extra_fields

### DIFF
--- a/src/eodash_catalog/generate_indicators.py
+++ b/src/eodash_catalog/generate_indicators.py
@@ -133,6 +133,7 @@ def extract_indicator_info(parent_collection: Collection):
         "sensor",
         "cities",
         "countries",
+        "thumbnail",
     ]
     summaries: dict[str, Any] = {}
     for key in to_extract:

--- a/src/eodash_catalog/stac_handling.py
+++ b/src/eodash_catalog/stac_handling.py
@@ -297,6 +297,8 @@ def add_collection_information(
                 roles=["thumbnail"],
             ),
         )
+        # bubble up thumbnail to extra fields
+        collection.extra_fields["thumbnail"] = f'{catalog_config["assets_endpoint"]}/{collection_config["Image"]}'
     # Add extra fields to collection if available
     add_extra_fields(collection, collection_config)
 

--- a/src/eodash_catalog/stac_handling.py
+++ b/src/eodash_catalog/stac_handling.py
@@ -297,8 +297,11 @@ def add_collection_information(
                 roles=["thumbnail"],
             ),
         )
-        # bubble up thumbnail to extra fields
-        collection.extra_fields["thumbnail"] = f'{catalog_config["assets_endpoint"]}/{collection_config["Image"]}'
+        # Bubble up thumbnail to extra fields
+        collection.extra_fields["thumbnail"] = (
+            f'{catalog_config["assets_endpoint"]}/'
+            f'{collection_config["Image"]}'
+        )
     # Add extra fields to collection if available
     add_extra_fields(collection, collection_config)
 


### PR DESCRIPTION
In this PR I attempt to bubble up the `thumbnail` field in order to make it available in the `catalog.json`

How to run locally:
- run `eodash_catalog RECCAP2_12_intact_biomass_change_trend_mean` in the `eodash-catalog` repository
- check `eodash-catalog/build/trilateral/catalog.json` and it should look like below with thumbnail now part of `catalog.json`
```json
{
  ...
  "links": [
    {
       ...
    },
    {
      "rel": "child",
      "href": "./RECCAP2_12_intact_biomass_change_trend_mean/collection.json",
      "type": "application/json",
      "title": "Mean intact biomass change trend (CCI RECCAP2)",
      "code": "RECCAP2_12",
      "id": "RECCAP2_12_intact_biomass_change_trend_mean",
      "themes": [
        "biomass"
      ],
      "subcode": "RECCAP2_12",
      "satellite": [
        "SMOS"
      ],
      "sensor": [
        "MIRAS"
      ],
      "thumbnail": [
        "https://raw.githubusercontent.com/eurodatacube/eodash-assets/main/collections/RECCAP2_9_intact_biomass_change_methods_mean/World-RECCAP2_9.png"
      ],
      "tags": [
        "Amazon rainforest",
        "Open data",
        "Carbon",
        "Forest"
      ],
      "agency": [
        "ESA"
      ]
    },
    {
      ...
    }
  ],
  "title": "Earth Observing Dashboard"
}
```

This allows us to display the thumbnail in the `eox-itemfilter` cards
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/9feb224a-fec1-49b6-8422-cd4b9e8d48e8" />
