### PR TITLE
feat: Introduce `Disable` Collection

### DIFF
--- a/src/eodash_catalog/endpoints.py
+++ b/src/eodash_catalog/endpoints.py
@@ -822,7 +822,7 @@ def add_visualization_info(
             data_projection = str(endpoint_config.get("DataProjection", 3857))
             epsg_prefix = "" if "EPSG:" in data_projection else "EPSG:"
             crs = f"{epsg_prefix}{data_projection}"
-            time = stac_object.get_datetime() if isinstance(stac_object,Item) else "{{time}}"
+            time = stac_object.get_datetime() if isinstance(stac_object, Item) else "{{time}}"
             target_url = (
                 "{}/tiles/{}/{}/{{z}}/{{y}}/{{x}}" "?crs={}&time={}&vmin={}&vmax={}&cbar={}"
             ).format(

--- a/src/eodash_catalog/endpoints.py
+++ b/src/eodash_catalog/endpoints.py
@@ -120,6 +120,7 @@ def process_STAC_Datacube_Endpoint(
             geometry=item.geometry,
             datetime=dt,
         )
+        add_visualization_info(new_item, collection_config, endpoint_config)
         link = collection.add_item(new_item)
         # bubble up information we want to the link
         link.extra_fields["datetime"] = format_datetime_to_isostring_zulu(dt)
@@ -821,13 +822,15 @@ def add_visualization_info(
             data_projection = str(endpoint_config.get("DataProjection", 3857))
             epsg_prefix = "" if "EPSG:" in data_projection else "EPSG:"
             crs = f"{epsg_prefix}{data_projection}"
+            time = stac_object.get_datetime() if isinstance(stac_object,Item) else "{{time}}"
             target_url = (
-                "{}/tiles/{}/{}/{{z}}/{{y}}/{{x}}" "?crs={}&time={{time}}&vmin={}&vmax={}&cbar={}"
+                "{}/tiles/{}/{}/{{z}}/{{y}}/{{x}}" "?crs={}&time={}&vmin={}&vmax={}&cbar={}"
             ).format(
                 endpoint_config["EndPoint"],
                 endpoint_config["DatacubeId"],
                 endpoint_config["Variable"],
                 crs,
+                time,
                 vmin,
                 vmax,
                 cbar,


### PR DESCRIPTION
By assigning a collection to the newly introduced `Disable` option in the indicator configuration a `"disable"` role will be added to the collection link on the indicator.
E.g config:
```yaml
...

Collections:
  - E10a2_agricultural_production_area
  - E10a3_agricultural_production_area_change
  - E10a1_agricultural_production_productive_area
  - E10a9_agricultural_workers
  - E10a5_fruit_production
  - E10a6_harvested_parcels_evolution
  - E10a10_harvesting_evolution_winter_cereal
  - E10a10_2_harvesting_evolution_winter_rapeseed
  - E10a8_winter_cereals

Disable:
  - E10a3_agricultural_production_area_change
```
the corresponding indicator link:
```json
{
      "rel": "child",
      "href": "./agricultural_production_area_change/collection.json",
      "type": "application/json",
      "roles": [
        "disable"
      ],
     ... 
    },
```