### PR TITLE
Process handling of Locations and Subcollections configs

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -5,4 +5,4 @@ target-version = "py312"
 
 [lint]
 select = ["E", "F", "UP", "B", "SIM", "I", "W", "C90", "ASYNC", "A", "C4", "PERF", "RUF"]
-ignore = ["B019", "C901", "UP017"]
+ignore = ["B019", "C901", "UP017", "C419"]

--- a/src/eodash_catalog/endpoints.py
+++ b/src/eodash_catalog/endpoints.py
@@ -17,6 +17,7 @@ from eodash_catalog.sh_endpoint import get_SH_token
 from eodash_catalog.stac_handling import (
     add_collection_information,
     add_example_info,
+    add_process_info_child_collection,
     add_projection_info,
     get_collection_datetimes_from_config,
     get_or_create_collection,
@@ -174,7 +175,7 @@ def handle_STAC_based_endpoint(
                 collection.description = location["Name"]
             # TODO: should we remove all assets from sub collections?
             link = root_collection.add_child(collection)
-            latlng = f'{location["Point"][1]},{location["Point"][0]}'
+            latlng = f'{location["Point"][1]},{location["Point"][0]}'.strip()
             # Add extra properties we need
             link.extra_fields["id"] = location["Identifier"]
             link.extra_fields["latlng"] = latlng
@@ -182,6 +183,7 @@ def handle_STAC_based_endpoint(
             add_example_info(collection, collection_config, endpoint_config, catalog_config)
             # eodash v4 compatibility
             add_visualization_info(collection, collection_config, endpoint_config)
+            add_process_info_child_collection(collection, catalog_config, collection_config)
             if "OverwriteBBox" in location:
                 collection.extent.spatial = SpatialExtent(
                     [
@@ -406,7 +408,7 @@ def handle_SH_WMS_endpoint(
 
             link = root_collection.add_child(collection)
             # bubble up information we want to the link
-            latlng = "{},{}".format(location["Point"][1], location["Point"][0])
+            latlng = "{},{}".format(location["Point"][1], location["Point"][0]).strip()
             link.extra_fields["id"] = location["Identifier"]
             link.extra_fields["latlng"] = latlng
             link.extra_fields["country"] = location["Country"]
@@ -416,6 +418,7 @@ def handle_SH_WMS_endpoint(
             else:
                 LOGGER.warn(f"NO datetimes configured for collection: {collection_config['Name']}!")
             add_visualization_info(collection, collection_config, endpoint_config)
+            add_process_info_child_collection(collection, catalog_config, collection_config)
 
         root_collection.update_extent_from_items()
         # Add bbox extents from children

--- a/src/eodash_catalog/endpoints.py
+++ b/src/eodash_catalog/endpoints.py
@@ -210,7 +210,7 @@ def handle_STAC_based_endpoint(
         )
     # eodash v4 compatibility
     add_visualization_info(root_collection, collection_config, endpoint_config)
-    add_collection_information(catalog_config, root_collection, collection_config)
+    add_collection_information(catalog_config, root_collection, collection_config, True)
     add_example_info(root_collection, collection_config, endpoint_config, catalog_config)
     return root_collection
 
@@ -446,7 +446,7 @@ def handle_SH_WMS_endpoint(
             item_link = root_collection.add_item(item)
             item_link.extra_fields["datetime"] = format_datetime_to_isostring_zulu(dt)
     # eodash v4 compatibility
-    add_collection_information(catalog_config, root_collection, collection_config)
+    add_collection_information(catalog_config, root_collection, collection_config, True)
     add_visualization_info(root_collection, collection_config, endpoint_config)
     return root_collection
 

--- a/src/eodash_catalog/generate_indicators.py
+++ b/src/eodash_catalog/generate_indicators.py
@@ -178,7 +178,7 @@ def process_indicator_file(
     else:
         # we assume that collection files can also be loaded directly
         process_collection_file(catalog_config, file_path, parent_indicator, options)
-    add_collection_information(catalog_config, parent_indicator, indicator_config)
+    add_collection_information(catalog_config, parent_indicator, indicator_config, True)
     if iter_len_at_least(parent_indicator.get_items(recursive=True), 1):
         parent_indicator.update_extent_from_items()
     # Add bbox extents from children

--- a/src/eodash_catalog/stac_handling.py
+++ b/src/eodash_catalog/stac_handling.py
@@ -213,7 +213,10 @@ def add_example_info(
 
 
 def add_collection_information(
-    catalog_config: dict, collection: Collection, collection_config: dict
+    catalog_config: dict,
+    collection: Collection,
+    collection_config: dict,
+    is_root_collection: bool = False,
 ) -> None:
     # Add metadata information
     # Check license identifier
@@ -322,7 +325,7 @@ def add_collection_information(
             f'{catalog_config["assets_endpoint"]}/' f'{collection_config["Image"]}'
         )
     # Add extra fields to collection if available
-    add_extra_fields(collection, collection_config)
+    add_extra_fields(collection, collection_config, is_root_collection)
 
     if "References" in collection_config:
         generic_counter = 1
@@ -452,12 +455,16 @@ def add_base_overlay_info(
             collection.add_link(create_web_map_link(layer, role="overlay"))
 
 
-def add_extra_fields(stac_object: Collection | Link, collection_config: dict) -> None:
+def add_extra_fields(
+    stac_object: Collection | Link, collection_config: dict, is_root_collection: bool = False
+) -> None:
     if "yAxis" in collection_config:
         stac_object.extra_fields["yAxis"] = collection_config["yAxis"]
     if "Themes" in collection_config:
         stac_object.extra_fields["themes"] = collection_config["Themes"]
-    if "Locations" in collection_config or "Subcollections" in collection_config:
+    if (
+        "Locations" in collection_config or "Subcollections" in collection_config
+    ) and is_root_collection:
         stac_object.extra_fields["locations"] = True
     if "Tags" in collection_config:
         stac_object.extra_fields["tags"] = collection_config["Tags"]

--- a/src/eodash_catalog/stac_handling.py
+++ b/src/eodash_catalog/stac_handling.py
@@ -346,9 +346,8 @@ def add_collection_information(
 
 
 def add_process_info(collection: Collection, catalog_config: dict, collection_config: dict) -> None:
-    if "Locations" in collection_config:
+    if any(key in collection_config for key in ["Locations", "Subcollections"]):
         # add the generic geodb-like selection process on the root collection instead of Processes
-
         if "geodb_default_form" in catalog_config:
             # adding default geodb-like map handling for Locations
             collection.extra_fields["eodash:jsonform"] = get_full_url(

--- a/src/eodash_catalog/stac_handling.py
+++ b/src/eodash_catalog/stac_handling.py
@@ -348,11 +348,27 @@ def add_collection_information(
 def add_process_info(collection: Collection, catalog_config: dict, collection_config: dict) -> None:
     if "Locations" in collection_config:
         # add the generic geodb-like selection process on the root collection instead of Processes
+
         if "geodb_default_form" in catalog_config:
             # adding default geodb-like map handling for Locations
             collection.extra_fields["eodash:jsonform"] = get_full_url(
                 catalog_config["geodb_default_form"], catalog_config
             )
+        # link a process definition for getting a collection with {{feature}} placeholder
+        sl = Link(
+            rel="service",
+            target="./" + collection.id + "/{{feature}}/collection.json",
+            media_type="application/json; profile=collection",
+            extra_fields={
+                "id": "locations",
+                "method": "GET",
+                "type": "application/json; profile=collection",
+            },
+        )
+        collection.add_link(sl)
+    # elif is intentional for cases when Process is defined on collection with Locations
+    # then we want to only add it to the "children", not the root
+    elif "Process" in collection_config:
         if "EndPoints" in collection_config["Process"]:
             for endpoint in collection_config["Process"]["EndPoints"]:
                 collection.add_link(create_service_link(endpoint, catalog_config))

--- a/src/eodash_catalog/stac_handling.py
+++ b/src/eodash_catalog/stac_handling.py
@@ -362,6 +362,7 @@ def add_process_info(collection: Collection, catalog_config: dict, collection_co
                 "id": "locations",
                 "method": "GET",
                 "type": "application/json; profile=collection",
+                "endpoint": "STAC",
             },
         )
         collection.add_link(sl)

--- a/src/eodash_catalog/stac_handling.py
+++ b/src/eodash_catalog/stac_handling.py
@@ -346,7 +346,13 @@ def add_collection_information(
 
 
 def add_process_info(collection: Collection, catalog_config: dict, collection_config: dict) -> None:
-    if "Process" in collection_config:
+    if "Locations" in collection_config:
+        # add the generic geodb-like selection process on the root collection instead of Processes
+        if "geodb_default_form" in catalog_config:
+            # adding default geodb-like map handling for Locations
+            collection.extra_fields["eodash:jsonform"] = get_full_url(
+                catalog_config["geodb_default_form"], catalog_config
+            )
         if "EndPoints" in collection_config["Process"]:
             for endpoint in collection_config["Process"]["EndPoints"]:
                 collection.add_link(create_service_link(endpoint, catalog_config))
@@ -387,6 +393,24 @@ def add_process_info(collection: Collection, catalog_config: dict, collection_co
                         },
                     )
                 )
+
+
+def add_process_info_child_collection(
+    collection: Collection, catalog_config: dict, collection_config: dict
+) -> None:
+    # in case of locations, we add the process itself on a child collection
+    if "Process" in collection_config:
+        if "EndPoints" in collection_config["Process"]:
+            for endpoint in collection_config["Process"]["EndPoints"]:
+                collection.add_link(create_service_link(endpoint, catalog_config))
+        if "JsonForm" in collection_config["Process"]:
+            collection.extra_fields["eodash:jsonform"] = get_full_url(
+                collection_config["Process"]["JsonForm"], catalog_config
+            )
+        if "VegaDefinition" in collection_config["Process"]:
+            collection.extra_fields["eodash:vegadefinition"] = get_full_url(
+                collection_config["Process"]["VegaDefinition"], catalog_config
+            )
 
 
 def add_base_overlay_info(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -241,19 +241,28 @@ def test_collection_locations_processing(catalog_output_folder_json):
     root_collection_path = os.path.join(catalog_output_folder_json, collection_name)
     # perform checks on child locations
     with open(os.path.join(root_collection_path, "collection.json")) as fp:
-        collection_json: dict = json.load(fp)
-        # test that locations is set to true
-        assert collection_json["locations"] is True
-        links = collection_json["links"]
+        indicator_json: dict = json.load(fp)
+        # test that locations on indicator level is set to true
+        assert indicator_json["locations"] is True
+        links = indicator_json["links"]
         # test that link for custom process exists
         assert any([link.get("type") == "application/json; profile=collection" for link in links])
     child_collection_path = os.path.join(root_collection_path, collection_name)
-    location_dir = os.path.join(child_collection_path, "Balaton")
-    item_paths = os.listdir(location_dir)
+    with open(os.path.join(child_collection_path, "collection.json")) as fp:
+        collection_json: dict = json.load(fp)
+        # test that locations on collection level is set to true
+        assert collection_json["locations"] is True
+    location_folders = [
+        name
+        for name in os.listdir(child_collection_path)
+        if os.path.isdir(os.path.join(child_collection_path, name))
+    ]
     # we specify two locations in this test config
-    assert len(item_paths) == 2
-    with open(os.path.join(location_dir, item_paths[0])) as fp:
-        # check that child Location has a process defined
+    assert len(location_folders) == 2
+    location_dir = os.path.join(child_collection_path, "Balaton")
+    with open(os.path.join(location_dir, "collection.json")) as fp:
+        # check that child Location collection has a process defined
         child_json = json.load(fp)
         links = child_json["links"]
         assert any([link.get("endpoint") == "eoxhub_workspaces" for link in links])
+        assert "locations" not in child_json

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -233,3 +233,27 @@ def test_baselayer_with_custom_projection_added(catalog_output_folder):
         assert len(baselayer_links) == 1
         # test that custom proj4 definition is added to link
         assert baselayer_links[0]["eodash:proj4_def"]["name"] == "ORTHO:680500"
+
+
+def test_collection_locations_processing(catalog_output_folder_json):
+    # test that locations is true on root and process was added
+    collection_name = "test_locations_processing"
+    root_collection_path = os.path.join(catalog_output_folder_json, collection_name)
+    # perform checks on child locations
+    with open(os.path.join(root_collection_path, "collection.json")) as fp:
+        collection_json: dict = json.load(fp)
+        # test that locations is set to true
+        assert collection_json["locations"] is True
+        links = collection_json["links"]
+        # test that link for custom process exists
+        assert any([link.get("type") == "application/json; profile=collection" for link in links])
+    child_collection_path = os.path.join(root_collection_path, collection_name)
+    location_dir = os.path.join(child_collection_path, "Balaton")
+    item_paths = os.listdir(location_dir)
+    # we specify two locations in this test config
+    assert len(item_paths) == 2
+    with open(os.path.join(location_dir, item_paths[0])) as fp:
+        # check that child Location has a process defined
+        child_json = json.load(fp)
+        links = child_json["links"]
+        assert any([link.get("endpoint") == "eoxhub_workspaces" for link in links])

--- a/tests/testing-catalogs/testing-json.json
+++ b/tests/testing-catalogs/testing-json.json
@@ -7,6 +7,7 @@
     "default_overlay_layers": "testing-layers/overlays",
     "assets_endpoint": "https://raw.githubusercontent.com/eurodatacube/eodash-assets/main/",
     "collections": [
-        "test_tif_demo_1_json"
+        "test_tif_demo_1_json",
+        "test_locations_processing"
     ]
 }

--- a/tests/testing-collections/test_locations_processing.json
+++ b/tests/testing-collections/test_locations_processing.json
@@ -1,0 +1,69 @@
+{
+  "Name": "test_locations_processing",
+  "Title": "Lakes collection (Sentinel 2)",
+  "EodashIdentifier": "Lakes_S2L2A",
+  "Description": "Lakes_S2L2A/Lakes_S2L2A.md",
+  "Themes": ["water"],
+  "Tags": ["Sentinel", "Open data", "Water extent"],
+  "DataSource": {
+    "Spaceborne": {
+      "Satellite": ["Sentinel-2"],
+      "Sensor": ["MSI"]
+    }
+  },
+  "Agency": ["European Commission", "ESA"],
+  "Image": "Lakes_S2L2A/thumbnail.png",
+  "References": [
+    {
+      "Name": "Copernicus Sentinel-2 mission",
+      "Url": "https://www.esa.int/Applications/Observing_the_Earth/Copernicus/Sentinel-2"
+    }
+  ],
+  "Locations": [
+    {
+      "Identifier": "Tonle_sap",
+      "Country": ["KH"],
+      "Name": "Tonl\u00e9 Sap",
+      "Point": [104.2, 12.7],
+      "Bbox": [101.938, 11.945, 106.37, 14.0674],
+      "Times": ["2023-04-03", "2023-04-18"]
+    },
+    {
+      "Identifier": "Balaton",
+      "Country": ["HU"],
+      "Name": "Balaton",
+      "Point": [17.77, 46.825],
+      "Bbox": [17.08, 46.55, 18.24, 47.12],
+      "Times": ["2023-05-22", "2023-06-01"]
+    }
+  ],
+  "Resources": [
+    {
+      "EndPoint": "https://services.sentinel-hub.com",
+      "Name": "Sentinel Hub WMS",
+      "CollectionId": "sentinel-2-l2a",
+      "LayerId": "SENTINEL-2-L2A-TRUE-COLOR"
+    }
+  ],
+  "Process": {
+    "Name": "Test Process",
+    "JsonForm": "https://santilland.github.io/process_example/master/definitions/geodbform.json",
+    "EndPoints": [
+      {
+        "Identifier": "polarwarpcollection",
+        "Url": "https://example.com/",
+        "Method": "POST",
+        "EndPoint": "eoxhub_workspaces",
+        "Body": "https://santilland.github.io/process_example/definitions/harshness_body.json",
+        "Type": "image/tiff",
+        "Flatstyle": "https://santilland.github.io/process_example/definitions/harshness_style.json"
+      }
+    ]
+  },
+  "Provider": [
+    {
+      "Name": "Copernicus",
+      "Url": "https://www.copernicus.eu/en/access-data/conventional-data-access-hubs"
+    }
+  ]
+}


### PR DESCRIPTION
For "Locations" and "Subcollections" configs

Adds following STAC link for root collection (processing link with a templated feature name)

```json
{
      "rel": "service",
      "href": "./ADD_Landsat_L2_Antarctica/{{feature}}/collection.json",
      "type": "application/json; profile=collection",
      "id": "locations",
      "method": "GET"
},
```
and adds a standard geodb jsonform on it
```json
"eodash:jsonform": "https://santilland.github.io/process_example/definitions/geodbform.json",
```

Additionally bubbles down the `Process` definitions to the individual location collections if defined in config instead of putting it on the root collection in case of Locations.

@A-Behairi Could you please review :arrow_double_up: if the format is fine like the one we need and discussed?