### PR TITLE
Feat: Geodb locations logic

### DIFF
--- a/src/eodash_catalog/endpoints.py
+++ b/src/eodash_catalog/endpoints.py
@@ -590,11 +590,15 @@ def handle_GeoDB_endpoint(
                                 extra_fields=extra_fields,
                             )
                             item.add_link(link)
-                            locations_collection.add_item(item)
+                            itemlink = locations_collection.add_item(item)
+                            itemlink.extra_fields["datetime"] = format_datetime_to_isostring_zulu(
+                                time_object
+                            )
 
             # add_visualization_info(
             #     item, collection_config, endpoint_config, file_url=first_match.get("FileUrl")
             # )
+        locations_collection.extra_fields["subcode"] = key
         link = collection.add_child(locations_collection)
         locations_collection.update_extent_from_items()
         # collection.update_extent_from_items()

--- a/src/eodash_catalog/endpoints.py
+++ b/src/eodash_catalog/endpoints.py
@@ -591,8 +591,8 @@ def handle_GeoDB_endpoint(
                             )
                             item.add_link(link)
                             itemlink = locations_collection.add_item(item)
-                            itemlink.extra_fields["datetime"] = format_datetime_to_isostring_zulu(
-                                time_object
+                            itemlink.extra_fields["datetime"] = (
+                                f"{format_datetime_to_isostring_zulu(time_object)}Z"
                             )
 
             # add_visualization_info(

--- a/src/eodash_catalog/endpoints.py
+++ b/src/eodash_catalog/endpoints.py
@@ -533,7 +533,7 @@ def handle_GeoDB_endpoint(
             "Description": f"{city} - {country}",
         }
         locations_collection = get_or_create_collection(
-            collection, city, sc_config, catalog_config, endpoint_config
+            collection, key, sc_config, catalog_config, endpoint_config
         )
         input_data = endpoint_config.get("InputData")
         if input_data:
@@ -595,14 +595,14 @@ def handle_GeoDB_endpoint(
             # add_visualization_info(
             #     item, collection_config, endpoint_config, file_url=first_match.get("FileUrl")
             # )
-        collection.add_child(locations_collection)
+        link = collection.add_child(locations_collection)
         locations_collection.update_extent_from_items()
         # collection.update_extent_from_items()
         # bubble up information we want to the link
-        # link.extra_fields["id"] = key
-        # link.extra_fields["latlng"] = latlon
-        # link.extra_fields["country"] = country
-        # link.extra_fields["city"] = city
+        link.extra_fields["id"] = key
+        link.extra_fields["latlng"] = latlon
+        link.extra_fields["country"] = country
+        link.extra_fields["name"] = city
 
     if "yAxis" not in collection_config:
         # fetch yAxis and store it to data, preventing need to save it per dataset in yml
@@ -618,7 +618,8 @@ def handle_GeoDB_endpoint(
         collection_config["yAxis"] = yAxis
     add_collection_information(catalog_config, collection, collection_config)
     add_example_info(collection, collection_config, endpoint_config, catalog_config)
-    collection.extra_fields["geoDBID"] = endpoint_config["CollectionId"]
+    # collection.extra_fields["geoDBID"] = endpoint_config["CollectionId"]
+    collection.extra_fields["locations"] = True
 
     collection.update_extent_from_items()
     collection.summaries = Summaries(

--- a/src/eodash_catalog/generate_indicators.py
+++ b/src/eodash_catalog/generate_indicators.py
@@ -368,7 +368,10 @@ def add_to_catalog(
 
     link: Link = catalog.add_child(collection)
     # bubble fields we want to have up to collection link and add them to collection
-    if endpoint and "Type" in endpoint:
+    if endpoint and "Type" in endpoint and endpoint["Type"] not in ["GeoDB"]:
+        print(
+            f"Adding endpoint type {endpoint['Type']} for collection {collection.id} with name {endpoint['Name']}"
+        )
         collection.extra_fields["endpointtype"] = "{}_{}".format(
             endpoint["Name"],
             endpoint["Type"],
@@ -378,8 +381,9 @@ def add_to_catalog(
             endpoint["Type"],
         )
     elif endpoint:
-        collection.extra_fields["endpointtype"] = endpoint["Name"]
-        link.extra_fields["endpointtype"] = endpoint["Name"]
+        pass
+        # collection.extra_fields["endpointtype"] = endpoint["Name"]
+        # link.extra_fields["endpointtype"] = endpoint["Name"]
     if "Subtitle" in collection_config:
         link.extra_fields["subtitle"] = collection_config["Subtitle"]
     link.extra_fields["title"] = collection.title

--- a/src/eodash_catalog/generate_indicators.py
+++ b/src/eodash_catalog/generate_indicators.py
@@ -370,7 +370,8 @@ def add_to_catalog(
     # bubble fields we want to have up to collection link and add them to collection
     if endpoint and "Type" in endpoint and endpoint["Type"] not in ["GeoDB"]:
         print(
-            f"Adding endpoint type {endpoint['Type']} for collection {collection.id} with name {endpoint['Name']}"
+            f"Adding endpoint type {endpoint['Type']} for collection {collection.id} "
+            f"with name {endpoint['Name']}"
         )
         collection.extra_fields["endpointtype"] = "{}_{}".format(
             endpoint["Name"],

--- a/src/eodash_catalog/stac_handling.py
+++ b/src/eodash_catalog/stac_handling.py
@@ -369,6 +369,17 @@ def add_process_info(collection: Collection, catalog_config: dict, collection_co
             },
         )
         collection.add_link(sl)
+        # adding additional service links
+        if "EndPoints" in collection_config["Process"]:
+            for endpoint in collection_config["Process"]["EndPoints"]:
+                collection.add_link(create_service_link(endpoint, catalog_config))
+
+        # for geodb collections now based on locations, we want to make sure
+        # also manually defined processes are added to the collection
+        if "VegaDefinition" in collection_config["Process"]:
+            collection.extra_fields["eodash:vegadefinition"] = get_full_url(
+                collection_config["Process"]["VegaDefinition"], catalog_config
+            )
     # elif is intentional for cases when Process is defined on collection with Locations
     # then we want to only add it to the "children", not the root
     elif "Process" in collection_config:
@@ -387,10 +398,10 @@ def add_process_info(collection: Collection, catalog_config: dict, collection_co
         # see if geodb resource configured use defaults if available
         for resource in collection_config["Resources"]:
             if resource["Name"] == "GeoDB":
-                if "geodb_default_form" in catalog_config:
-                    collection.extra_fields["eodash:jsonform"] = get_full_url(
-                        catalog_config["geodb_default_form"], catalog_config
-                    )
+                # if "geodb_default_form" in catalog_config:
+                #     collection.extra_fields["eodash:jsonform"] = get_full_url(
+                #         catalog_config["geodb_default_form"], catalog_config
+                #     )
                 if "geodb_default_vega" in catalog_config:
                     collection.extra_fields["eodash:vegadefinition"] = get_full_url(
                         catalog_config["geodb_default_vega"], catalog_config


### PR DESCRIPTION
Implementation of extracting input_data to create collections for each POI (aoi_id).
Needs to add `InputData` definition as part of GeoDB resource as well as `Locations: True` in order to be activated.
If not configured with this implementation an itemless(empty) collection will be created instead of an item per POI.
  
```
Locations: True
Resources:
- EndPoint: https://xcube-geodb.brockmann-consult.de/eodash/6bf15325-f6a0-4b6a-bf80-a2491753f8f2/
  Name: GeoDB
  Database: eodash
  CollectionId: E9_tri
  InputData:
  - Identifier: ALOS-2
    Url: https://services.sentinel-hub.com/ogc/wms/
    Type: WMS
    Layers: 'AWS_JAXA_CARS_CONTAINERS_ALOS2'
    # TimeDelta: 720 # in minutes
  - Identifier: Sentinel-1
    Url: https://services.sentinel-hub.com/ogc/wms/
    Type: WMS
    Layers: 'E8_SENTINEL1'
```
